### PR TITLE
Complete Caixa administration forms

### DIFF
--- a/vcerp_principal/vcerp_caixa/admin.py
+++ b/vcerp_principal/vcerp_caixa/admin.py
@@ -1,8 +1,14 @@
 from django.contrib import admin
-from .models import Caixa
+from .models import Caixa, CaixaLog
 
 @admin.register(Caixa)
 class CaixaAdmin(admin.ModelAdmin):
     list_display = ('numero', 'status', 'usuario')
     list_filter = ('status',)
     search_fields = ('numero', 'usuario__username')
+
+
+@admin.register(CaixaLog)
+class CaixaLogAdmin(admin.ModelAdmin):
+    list_display = ('caixa', 'usuario', 'acao', 'data_hora')
+    list_filter = ('acao', 'data_hora')

--- a/vcerp_principal/vcerp_caixa/forms.py
+++ b/vcerp_principal/vcerp_caixa/forms.py
@@ -1,0 +1,19 @@
+from django import forms
+from .models import Caixa
+
+class CaixaForm(forms.ModelForm):
+    """Formulário básico para criação e edição de caixas."""
+
+    class Meta:
+        model = Caixa
+        fields = [
+            'numero',
+            'status',
+            'usuario',
+            'data_abertura',
+            'data_fechamento',
+        ]
+        widgets = {
+            'data_abertura': forms.DateTimeInput(attrs={'type': 'datetime-local'}, format='%Y-%m-%dT%H:%M'),
+            'data_fechamento': forms.DateTimeInput(attrs={'type': 'datetime-local'}, format='%Y-%m-%dT%H:%M'),
+        }

--- a/vcerp_principal/vcerp_caixa/tests.py
+++ b/vcerp_principal/vcerp_caixa/tests.py
@@ -1,3 +1,24 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Caixa, CaixaLog
+
+
+class CaixaModelTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", password="1234")
+        self.caixa = Caixa.objects.create(numero="1", status="disponivel")
+
+    def test_abrir_e_fechar_caixa(self):
+        self.caixa.usuario = self.user
+        self.caixa.abrir()
+
+        self.assertEqual(self.caixa.status, "ocupado")
+        self.assertIsNotNone(self.caixa.data_abertura)
+
+        self.caixa.fechar()
+        self.assertEqual(self.caixa.status, "fechado")
+        self.assertIsNotNone(self.caixa.data_fechamento)
+
+        logs = CaixaLog.objects.filter(caixa=self.caixa)
+        self.assertEqual(logs.count(), 2)


### PR DESCRIPTION
## Summary
- add CaixaModelForm to manage cash desks
- register CaixaLog in admin
- add unit test for Caixa open/close

## Testing
- `python -m pytest vcerp_principal/vcerp_caixa/tests.py -vv` *(fails: ModuleNotFoundError: No module named 'django')*